### PR TITLE
Fixes #26 (k3s server ignores selected IP address due to initialization order)

### DIFF
--- a/kalavai_client/cli.py
+++ b/kalavai_client/cli.py
@@ -546,6 +546,9 @@ def pool__start(cluster_name, *others,  only_registered_users: bool=False, ip_ad
     if option == 0:
         console.log("Installation was cancelled and did not complete.")
         return
+
+    if node_name is None:
+        node_name = f"{socket.gethostname()}-{uuid.uuid4().hex[:6]}" 
     
     # if only registered users are allowed, check user has logged in
     user = defaultdict(lambda: None)
@@ -575,7 +578,7 @@ def pool__start(cluster_name, *others,  only_registered_users: bool=False, ip_ad
     generate_compose_config(
         role="server",
         vpn_token=vpn["key"],
-        node_name=socket.gethostname(),
+        node_name=node_name,
         node_labels=node_labels,
         is_public=location is not None
     )
@@ -623,7 +626,7 @@ def pool__start(cluster_name, *others,  only_registered_users: bool=False, ip_ad
         write_auth_key=write_auth_key,
         file=USER_LOCAL_SERVER_FILE,
         watcher_service=watcher_service,
-        node_name=socket.gethostname(),
+        node_name=node_name,
         cluster_name=cluster_name,
         public_location=location,
         user_api_key=user["api_key"])
@@ -764,7 +767,7 @@ def pool__join(token, *others, node_name=None):
             return
     
     if node_name is None:
-        node_name = socket.gethostname()
+        node_name = f"{socket.gethostname()}-{uuid.uuid4().hex[:6]}"
     
     # check token
     if not pool__check_token(token):
@@ -1090,7 +1093,7 @@ def pool__attach(token, *others, node_name=None):
     """
 
     if node_name is None:
-        node_name = socket.gethostname()
+        node_name = f"{socket.gethostname()}-{uuid.uuid4().hex[:6]}"
     
     # check that is not attached to another instance
     if os.path.exists(USER_LOCAL_SERVER_FILE):


### PR DESCRIPTION
## Issue:
When running kalavai pool start, the k3s server initializes before the IP selection process, leading it to auto-detect an incorrect IP (e.g., 10.0.2.15 instead of 192.168.1.1).

## Changes:
- Modified pool__start() in cli.py to select the IP before starting k3s.
- Updated generate_compose_config() to accept and pass node_ip.
- Updated Docker Compose template to use --node_ip={{node_ip}}.